### PR TITLE
Ifdef

### DIFF
--- a/jhala-course-page.cabal
+++ b/jhala-course-page.cabal
@@ -18,4 +18,5 @@ executable homepage
   ghc-options:         -threaded
   build-depends:       base,
                        hakyll,
-                       pandoc
+                       pandoc,
+                       pandoc-types

--- a/site.hs
+++ b/site.hs
@@ -23,7 +23,7 @@ crunchWithCtxOpt ctx opt = do
   compile $ pandocCompilerWithTransform
               defaultHakyllReaderOptions
               defaultHakyllWriterOptions
-              (walk $ toggleMode)
+              (walk (toggleMode . haskellizeBlock) . walk haskellizeInline)
             >>= loadAndApplyTemplate "templates/page.html"    ctx
             >>= loadAndApplyTemplate "templates/default.html" ctx
             >>= relativizeUrls
@@ -38,6 +38,16 @@ toggleMode (OrderedList (_, UpperRoman, _) items) = select items
       if key == mode then payload else select rest
     select _ = Null
 toggleMode b = b
+
+-- | Make inline code Haskell by default
+haskellizeInline :: Inline -> Inline
+haskellizeInline (Code (ident, [], kvs) str) = Code (ident, ["haskell"], kvs) str
+haskellizeInline i = i
+
+-- | Make code blocks Haskell by default
+haskellizeBlock :: Block -> Block
+haskellizeBlock (CodeBlock (ident, [], kvs) str) = CodeBlock (ident, ["haskell"], kvs) str
+haskellizeBlock b = b
 
 --------------------------------------------------------------------------------
 main :: IO ()

--- a/site.hs
+++ b/site.hs
@@ -1,8 +1,14 @@
 --------------------------------------------------------------------------------
 {-# LANGUAGE OverloadedStrings #-}
 import Data.Monoid (mappend)
+import Data.List
 import Hakyll
 import Text.Pandoc
+import Text.Pandoc.Walk (walk)
+import System.Environment
+
+mode = "lecture"
+-- mode = "final"
 
 crunchWithCtx ctx = do
   route   $ setExtension "html"
@@ -11,7 +17,26 @@ crunchWithCtx ctx = do
             >>= loadAndApplyTemplate "templates/default.html" ctx
             >>= relativizeUrls
 
+crunchWithCtxOpt ctx opt = do
+  route   $ setExtension "html"
+  compile $ pandocCompilerWithTransform
+              defaultHakyllReaderOptions
+              defaultHakyllWriterOptions
+              (walk $ toggleMode)
+            >>= loadAndApplyTemplate "templates/page.html"    ctx
+            >>= loadAndApplyTemplate "templates/default.html" ctx
+            >>= relativizeUrls
 
+-- | Treat an ordered list with uppercase roman numerals as a map:
+-- in each item, the first paragraph is the key, and the second is the value;
+-- pick the value with key `mode` and discard all other items
+toggleMode :: Block -> Block
+toggleMode (OrderedList (_, UpperRoman, _) items) = select items
+  where
+    select ([Para [Str key], payload] : rest) =
+      if key == mode then payload else select rest
+    select _ = Null
+toggleMode b = b
 
 --------------------------------------------------------------------------------
 main :: IO ()
@@ -19,7 +44,7 @@ main = hakyll $ do
   match "static/*/*"    $ do route idRoute
                              compile copyFileCompiler
   match (fromList tops) $ crunchWithCtx siteCtx
-  match "lectures/*"    $ crunchWithCtx postCtx
+  match "lectures/*"    $ crunchWithCtxOpt postCtx mode
   match "assignments/*" $ crunchWithCtx postCtx
   match "templates/*"   $ compile templateCompiler
 

--- a/site.hs
+++ b/site.hs
@@ -5,8 +5,9 @@ import Data.List
 import Hakyll
 import Text.Pandoc
 import Text.Pandoc.Walk (walk)
-import System.Environment
 
+-- | For conditional inclusion: the key you want to keep in the resulting html;
+--   all other keys will be removed
 mode = "lecture"
 -- mode = "final"
 
@@ -28,8 +29,8 @@ crunchWithCtxOpt ctx opt = do
             >>= relativizeUrls
 
 -- | Treat an ordered list with uppercase roman numerals as a map:
--- in each item, the first paragraph is the key, and the second is the value;
--- pick the value with key `mode` and discard all other items
+--   in each item, the first paragraph is the key, and the second is the value;
+--   pick the value with key `mode` and discard all other items
 toggleMode :: Block -> Block
 toggleMode (OrderedList (_, UpperRoman, _) items) = select items
   where


### PR DESCRIPTION
Add a pandoc filter to enable conditional inclusion of paragraphs into lecture notes.

**Example**

You can now write the following in your lecture .md files:

> (I) lecture
> 
>     ```haskell
>     FV(x)       = ???
>     ```
> 
> (I) final
> 
>     ```haskell
>     FV(x)       = {x}
>     ```

Now, defining `mode = "lecture"` in `site.hs` will include only the first snippet into the generated .html, while defining `mode = "final"` will include only the second one.

More generally, the syntax is: an ordered list, indexed by uppercase Roman numerals; each item consists of two paragraphs: a key and a value. The list gets replaced by the value whose key matches `mode`.